### PR TITLE
Enable auto dark mode

### DIFF
--- a/src/layouts/modal/NutritionModal.css
+++ b/src/layouts/modal/NutritionModal.css
@@ -22,7 +22,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: rgba(240, 240, 240, 0.75);
+    background-color: rgb(from var(--md-sys-color-surface) r g b / 0.75);
 }
 
 .nutrition-table {

--- a/src/material-theme/theme.css
+++ b/src/material-theme/theme.css
@@ -2,6 +2,6 @@
 @import url(colors.module.css);
 @import url(typography.module.css);
 @import url(theme.light.css); /*(prefers-color-scheme: light);*/
-/*@import url(theme.dark.css) (prefers-color-scheme: dark);*/
+@import url(theme.dark.css) (prefers-color-scheme: dark);
 
 


### PR DESCRIPTION
I enabled dark mode support to save my eyes when I check the next day's meals late at night.

Was there any specific reason this was previously commented out?