### PR TITLE
Better separation of the nutrition modal

### DIFF
--- a/src/layouts/modal/NutritionModal.css
+++ b/src/layouts/modal/NutritionModal.css
@@ -14,6 +14,8 @@
     border-radius: 1em;
     padding: 1em;
     overflow: hidden;
+
+    box-shadow: 0 0 50px 10px rgb(var(--md-sys-color-shadow-rgb) / 0.25);
 }
 
 .Overlay {
@@ -23,6 +25,7 @@
     right: 0;
     bottom: 0;
     background-color: rgb(from var(--md-sys-color-surface) r g b / 0.75);
+    backdrop-filter: blur(3px);
 }
 
 .nutrition-table {


### PR DESCRIPTION
I added a shadow behind the content and blurred the background. Unfortunately, `backdrop-filter` is [not that widely supported](https://caniuse.com/css-backdrop-filter), but the shadow goes a long way on its own :)

![Screenshot_20240902_144109](https://github.com/user-attachments/assets/4d4abcc0-6e43-4dfb-ba64-9cfa2ebac6be)
![Screenshot_20240902_144135](https://github.com/user-attachments/assets/6b12f77d-bbcc-4045-96d3-79a2c5208897)
